### PR TITLE
Update inheritance error (unknown parent)

### DIFF
--- a/src/angular-inheritance.js
+++ b/src/angular-inheritance.js
@@ -59,7 +59,7 @@
                 extend(childConstructor, parentConstructor);
             }
             else {
-                throw 'The name' + parentName + ' does not refer to any constructor. Did you forget to define/include it ?';
+                throw 'The name ' + parentName + ' does not refer to any constructor. Did you forget to define/include it ?';
             }
         }
 


### PR DESCRIPTION
Add a space in the excpetion string which improves the reading of the error separating the string "name" and the printed variable "parentName".
